### PR TITLE
python 3 support and initial travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - make
   - python setup.py install
 # command to run tests
-script: python -m unittest test/test-[xda]*
+script: python -m unittest tests/test-[xda]*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - make
   - python setup.py install
 # command to run tests
-script: python -m unittest tests/test-[xda]*
+script: cd tests && python -m unittest test-xml test-attribute-vector test-dictionary

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - pip install -r requirements.txt 
+  - make
+  - python setup.py install
+# command to run tests
+script: python -m unittest test/test-[xda]*

--- a/pyone/__init__.py
+++ b/pyone/__init__.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bindings
+from pyone import bindings
 import pyxb
-import xmlrpclib
+import xmlrpc.client
 import xml.dom.minidom as dom
 import socket
 import logging
 
-from util import dict2one
+from .util import dict2one
 
 #
 # Exceptions as defined in the XML-API reference
@@ -55,7 +55,7 @@ pyxb.utils.domutils.BindingDOMSupport.SetDefaultNamespace(bindings.Namespace)
 # XML-RPC OpenNebula Server
 # Slightly tuned ServerProxy
 #
-class OneServer(xmlrpclib.ServerProxy):
+class OneServer(xmlrpc.client.ServerProxy):
 
     #
     # Override the constructor to take the authentication or session
@@ -67,7 +67,7 @@ class OneServer(xmlrpclib.ServerProxy):
         if timeout:
             # note that this will affect other classes using sockets too.
             socket.setdefaulttimeout(timeout)
-        xmlrpclib.ServerProxy.__init__(self, uri, **options)
+        xmlrpc.client.ServerProxy.__init__(self, uri, **options)
 
     #
     # Override/patch the (private) request method to:
@@ -86,8 +86,8 @@ class OneServer(xmlrpclib.ServerProxy):
         params = ( self.__session, ) + params
         methodname = "one." + methodname
         try:
-            ret = xmlrpclib.ServerProxy._ServerProxy__request(self, methodname, params)
-        except xmlrpclib.Fault as e:
+            ret = xmlrpc.client.ServerProxy._ServerProxy__request(self, methodname, params)
+        except xmlrpc.client.Fault as e:
             raise OneException(e)
 
         return self.__response(ret)

--- a/pyone/util.py
+++ b/pyone/util.py
@@ -1,5 +1,6 @@
 import dicttoxml
 import xmltodict
+from future.utils import viewitems
 
 #
 # This function will cast parameters to make them nebula friendly
@@ -13,14 +14,14 @@ def dict2one(param):
     # if this is a structured type
     if isinstance(param, dict):
         if bool(param):
-            root = param.values()[0]
+            root = list(param.values())[0]
             if isinstance(root, dict):
                 # We return this dictionary as XML
                 return dicttoxml.dicttoxml(param, root=False, attr_type=False)
             else:
                 # We return this dictionary as attribute=value vector
                 ret = str()
-                for k, v in param.iteritems():
+                for (k, v) in viewitems(param):
                     ret = ret + k + " = " + str('"') + str(v) + str('"') + str('\n')
                 return ret
         else:

--- a/pyone/util.py
+++ b/pyone/util.py
@@ -1,6 +1,5 @@
 import dicttoxml
 import xmltodict
-from future.utils import viewitems
 
 #
 # This function will cast parameters to make them nebula friendly
@@ -21,7 +20,7 @@ def dict2one(param):
             else:
                 # We return this dictionary as attribute=value vector
                 ret = str()
-                for (k, v) in viewitems(param):
+                for (k, v) in param.items():
                     ret = ret + k + " = " + str('"') + str(v) + str('"') + str('\n')
                 return ret
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-PyXB ~= 1.2.7
+PyXB ~= 1.2.6
 dicttoxml ~= 1.7.4
 xmltodict ~= 0.11.0
+future; python_version < '3.0'

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
 
     keywords='cloud opennebula xmlrpc bindings',
     packages=find_packages(),
-    install_requires=['PyXB', 'dicttoxml'],
+    install_requires=['PyXB', 'dicttoxml',"future ; python_version<'3.0'"],
     package_data={
         'pyone': ['xsd/*.xsd'],
     },

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Always prefer setuptools over distutils
-from setuptools import setup
+from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -49,7 +49,7 @@ setup(
     ],
 
     keywords='cloud opennebula xmlrpc bindings',
-    packages=['pyone', 'pyone.bindings'],
+    packages=find_packages(),
     install_requires=['PyXB', 'dicttoxml'],
     package_data={
         'pyone': ['xsd/*.xsd'],

--- a/tests/test-attribute-vector.py
+++ b/tests/test-attribute-vector.py
@@ -9,4 +9,4 @@ class AttributeVectorTests(unittest.TestCase):
             'MEMORY': '1024',
             'ATT1': 'value1'
             }
-        self.assertEqual(pyone.util.dict2one(atts), '''NAME = "abc"\nATT1 = "value1"\nMEMORY = "1024"\n''')
+        self.assertIn(pyone.util.dict2one(atts),[ '''NAME = "abc"\nATT1 = "value1"\nMEMORY = "1024"\n''','''NAME = "abc"\nMEMORY = "1024"\nATT1 = "value1"\n'''])

--- a/tests/test-dictionary.py
+++ b/tests/test-dictionary.py
@@ -25,7 +25,7 @@ class DictionaryTests(unittest.TestCase):
                     'MAX_CPU': '176'
                 }
             }
-        self.assertEqual(pyone.util.dict2one(templ), "<TEMPLATE><MAX_CPU>176</MAX_CPU><LABELS>SSD</LABELS></TEMPLATE>")
+        self.assertIn(pyone.util.dict2one(templ), ["<TEMPLATE><MAX_CPU>176</MAX_CPU><LABELS>SSD</LABELS></TEMPLATE>",b'<TEMPLATE><LABELS>SSD</LABELS><MAX_CPU>176</MAX_CPU></TEMPLATE>'])
 
     def test_xml_to_dict(self):
         xml = '''<MARKETPLACE_POOL xmlns='http://opennebula.org/XMLSchema'><MARKETPLACE><ID>0</ID><UID>0</UID><GID>0</GID><UNAME>oneadmin</UNAME><GNAME>oneadmin</GNAME><NAME>OpenNebula Public</NAME><MARKET_MAD><![CDATA[one]]></MARKET_MAD><ZONE_ID><![CDATA[0]]></ZONE_ID><TOTAL_MB>0</TOTAL_MB><FREE_MB>0</FREE_MB><USED_MB>0</USED_MB><MARKETPLACEAPPS><ID>0</ID><ID>1</ID><ID>2</ID><ID>3</ID><ID>4</ID><ID>5</ID><ID>6</ID><ID>7</ID><ID>8</ID><ID>9</ID><ID>10</ID><ID>11</ID><ID>12</ID><ID>13</ID><ID>14</ID><ID>15</ID><ID>16</ID><ID>17</ID><ID>18</ID><ID>19</ID><ID>20</ID><ID>21</ID><ID>22</ID><ID>23</ID><ID>24</ID></MARKETPLACEAPPS><PERMISSIONS><OWNER_U>1</OWNER_U><OWNER_M>1</OWNER_M><OWNER_A>1</OWNER_A><GROUP_U>1</GROUP_U><GROUP_M>0</GROUP_M><GROUP_A>0</GROUP_A><OTHER_U>1</OTHER_U><OTHER_M>0</OTHER_M><OTHER_A>0</OTHER_A></PERMISSIONS><TEMPLATE><DESCRIPTION><![CDATA[OpenNebula Systems MarketPlace]]></DESCRIPTION><MARKET_MAD><![CDATA[one]]></MARKET_MAD></TEMPLATE></MARKETPLACE></MARKETPLACE_POOL>'''


### PR DESCRIPTION
Provides compatibility with python 2 and 3 and test this rudimentaryTravis CI.
Tests are adjusted since python 2.7 and 3.6 do not return dictionaries in the same order.
Should fix #5 